### PR TITLE
fix: resolve CVE-2025-6965 (SQLite integer truncation)

### DIFF
--- a/UISampleSpark.Core/UISampleSpark.Core.csproj
+++ b/UISampleSpark.Core/UISampleSpark.Core.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Code scanning alert [#443](https://github.com/MakeBoldSolutions/UISampleSpark/security/code-scanning/443) flagged **CVE-2025-6965** (HIGH/critical) — an integer truncation vulnerability in SQLite versions before 3.50.2, reachable via `SQLitePCLRaw.lib.e_sqlite3 2.1.11`, pulled in transitively by `Microsoft.EntityFrameworkCore.Sqlite 10.0.9`.
- Adds a direct `SQLitePCLRaw.bundle_e_sqlite3` reference pinned to `3.0.3` in `UISampleSpark.Core.csproj`, which upgrades the resolved native SQLite build to `SourceGear.sqlite3 3.50.4.5` — past the 3.50.2 fix threshold. Confirmed via `dotnet list package --include-transitive` that the vulnerable `SQLitePCLRaw.lib.e_sqlite3 2.1.11` no longer appears anywhere in the graph.
- No source code changes required; this is a transitive dependency version pin.

## Test plan
- [x] `dotnet restore` — resolves `SourceGear.sqlite3 3.50.4.5` in place of the vulnerable native lib
- [x] `dotnet build UISampleSpark.sln` — succeeds, no new warnings/errors
- [x] `dotnet test UISampleSpark.Core.Tests` — 240/240 passing
- [ ] Confirm code scanning alert #443 closes automatically once this merges and a new scan runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)