### PR TITLE
fix: restore Core.Tests test discovery (MSTest adapter/framework mismatch)

### DIFF
--- a/UISampleSpark.Core.Tests/UISampleSpark.Core.Tests.csproj
+++ b/UISampleSpark.Core.Tests/UISampleSpark.Core.Tests.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- #217 bumped `MSTest.TestFramework` to 4.3.2 in isolation and was merged; #216 (which bumped `MSTest.TestAdapter` + `MSTest.TestFramework` together) was closed instead of merged.
- The resulting version mismatch (`TestAdapter 4.2.3` / `TestFramework 4.3.2`) silently breaks test discovery: `dotnet test` prints "No test is available" and exits **0**, so `main`'s CI has been reporting green while all 240 tests in `UISampleSpark.Core.Tests` are not actually running.
- Bumps `MSTest.TestAdapter` to `4.3.2` to match, restoring discovery.

## Verification
- Confirmed the failure is live on `main` (checked out `main`, cleaned bin/obj, ran `dotnet test` → "No test is available")
- After the fix: `dotnet test UISampleSpark.Core.Tests` → 240/240 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)