### PR TITLE
fix: grant security-events:write to docker-image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Investigating why code scanning alert [#443](https://github.com/MakeBoldSolutions/UISampleSpark/security/code-scanning/443) (CVE-2025-6965, fixed by #218) still shows **open**: the container-scan workflow's Trivy SARIF upload has been failing on every run since ~14:47 UTC today with `Resource not accessible by integration`.
- Root cause: the repo's default `GITHUB_TOKEN` workflow permission is `read` (checked via `gh api repos/.../actions/permissions/workflow`), and `docker-image.yml` never declared its own `permissions:` block, so it inherits read-only and can't upload SARIF results. `codeql-analysis.yml` already declares `security-events: write` explicitly, which is why CodeQL uploads keep working.
- Adds an explicit `permissions: { contents: read, security-events: write }` block to the `build` job, matching the existing pattern in `codeql-analysis.yml`.
- Not caused by any of the recent dependency-bump merges — timing was coincidental; likely a repo-settings change.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge, confirm the next `main` push's Docker workflow run completes the "Upload Trivy results to GitHub Security" step successfully
- [ ] Confirm alert #443 transitions to fixed/closed once a scan with the patched SQLite dependency uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)